### PR TITLE
Remove the button wrapper for the review and submit link

### DIFF
--- a/app/components/edit/submitted_step_component.html.erb
+++ b/app/components/edit/submitted_step_component.html.erb
@@ -16,9 +16,7 @@
 
   <% component.with_footer_content do %>
     <div class="d-flex justify-content-end align-items-baseline">
-      <%= render Elements::ButtonComponent.new(variant: :primary, disabled: !all_done?) do %>
-        <%= link_to 'Review and submit', review_submission_path(@submission.dissertation_id) %>
-      <% end %>
+      <%= review_link %>
     </div>
   <% end %>
 <% end %>

--- a/app/components/edit/submitted_step_component.rb
+++ b/app/components/edit/submitted_step_component.rb
@@ -18,5 +18,28 @@ module Edit
     def step_range_end
       SubmissionPresenter.total_steps - 1
     end
+
+    def review_link
+      link_to(review_submission_path(@submission.dissertation_id),
+              class: ComponentSupport::ButtonSupport.classes(variant: 'primary', classes:),
+              role: 'button',
+              aria:) do
+        'Review and submit'
+      end
+    end
+
+    private
+
+    def classes
+      return if all_done?
+
+      'disabled'
+    end
+
+    def aria
+      return if all_done?
+
+      { disabled: true }
+    end
   end
 end

--- a/spec/components/edit/submitted_step_component_spec.rb
+++ b/spec/components/edit/submitted_step_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Edit::SubmittedStepComponent, type: :component do
       expect(page).to have_css('h2', text: 'Review and submit to Registrar')
 
       expect(page).to have_css('.alert-danger', text: "You must complete sections 1-#{TOTAL_STEPS - 1}")
-      expect(page).to have_button('Review and submit', disabled: true)
+      expect(page).to have_link('Review and submit', class: 'disabled')
     end
   end
 
@@ -29,7 +29,7 @@ RSpec.describe Edit::SubmittedStepComponent, type: :component do
       expect(page).to have_css('h2', text: 'Review and submit to Registrar')
 
       expect(page).to have_css('.alert-info', text: "You have completed sections 1-#{TOTAL_STEPS - 1}")
-      expect(page).to have_button('Review and submit', disabled: false)
+      expect(page).to have_link('Review and submit')
     end
   end
 end

--- a/spec/system/edit_submission_spec.rb
+++ b/spec/system/edit_submission_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Edit Submission' do
     within(cards.last) do
       expect(page).to have_css('.alert-danger',
                                text: "You must complete sections 1-#{TOTAL_STEPS - 1}")
-      expect(page).to have_button('Review and submit', disabled: true)
+      expect(page).to have_link('Review and submit', class: 'disabled')
     end
 
     expect(page).to have_css('.progress-card li', count: TOTAL_STEPS)
@@ -207,7 +207,7 @@ RSpec.describe 'Edit Submission' do
     within(cards[7]) do
       expect(page).to have_css('.alert-info',
                                text: "You have completed sections 1-#{TOTAL_STEPS - 1}.")
-      click_button('Review and submit')
+      click_link_or_button('Review and submit')
     end
 
     expect(page).to have_current_path(review_submission_path(submission.dissertation_id))


### PR DESCRIPTION
Fixes #134 

Styles the link as a button and adds appropriate aria role and disabled data when appropriate.

Disabled:
<img width="916" height="264" alt="Screenshot 2025-08-25 at 3 10 13 PM" src="https://github.com/user-attachments/assets/0917232d-3f7a-4f7f-84a3-203388e63bd2" />

Enabled:
<img width="908" height="276" alt="Screenshot 2025-08-25 at 3 10 04 PM" src="https://github.com/user-attachments/assets/d43863a2-4465-4051-8bab-5a18747846c6" />
