### PR TITLE
Switch span to proper h1 in masthead

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -8,6 +8,10 @@
 
 .masthead {
   color: white;
+
+  h1 {
+    font-size: 2.25rem;
+  }
 }
 
 // Submission form

--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -30,7 +30,7 @@
         <div class="d-flex align-items-end gap-2 flex-grow-1">
           <span class="rosette-logo me-1 align-self-start flex-shrink-0" aria-hidden></span>
           <div class="me-1 flex-grow-1">
-            <div class="h1 my-0"><%= title %></div>
+            <h1 class="my-0"><%= title %></h1>
             <span class="h4 d-block my-1"><%= subtitle %></span>
           </div>
         </div>

--- a/spec/components/header_component_spec.rb
+++ b/spec/components/header_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe HeaderComponent, type: :component do
   it 'renders header' do
     render_inline(described_class.new(title: 'Test Header', subtitle: 'Test Subtitle', current_user:))
 
-    expect(page).to have_css('header .h1', text: 'Test Header')
+    expect(page).to have_css('header h1', text: 'Test Header')
     expect(page).to have_css('header .h4', text: 'Test Subtitle')
     expect(page).to have_text('Logged in: testuser')
   end


### PR DESCRIPTION
Fixes #140 

No visual changes, this just uses the proper h1 tag for accessibility.