### PR TITLE
Add sticky-top to progress bar component

### DIFF
--- a/app/components/shared/progress_card_component.html.erb
+++ b/app/components/shared/progress_card_component.html.erb
@@ -1,4 +1,4 @@
-<aside class="card progress-card" aria-label="Progress">
+<aside class="card progress-card sticky-top" aria-label="Progress">
   <div class="card-header">
     <h2 class="h4">Progress</h2>
   </div>


### PR DESCRIPTION
Fixers #92 

Adds `stick-top` to the progress bar so that it remains on the screen when scrolling - and maintains responsiveness on smaller screens:


https://github.com/user-attachments/assets/3cafb047-206a-4000-a500-4410dad511ee

Narrow screen:


https://github.com/user-attachments/assets/7abed7aa-5f97-4ba5-8762-58076f3bf157

