### PR TITLE
Fix HTML parse error in ProgressCardComponent

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,25 +16,25 @@ begin
   desc 'Run erblint against ERB files'
   task erblint: :environment do
     puts 'Running ERB linter...'
-    system('bin/erb_lint --lint-all --format compact')
+    sh('bin/erb_lint --lint-all --format compact')
   end
 
   desc 'Run herb against ERB files'
   task herb: :environment do
     puts 'Running ERB linter...'
-    system('bin/herb analyze app --no-log-file --non-interactive --no-timing')
+    sh('bin/herb analyze app --no-log-file --non-interactive --no-timing')
   end
 
   desc 'Run linter against JS files'
   task eslint: :environment do
     puts 'Running JS linter...'
-    system('yarn run lint')
+    sh('yarn run lint')
   end
 
   desc 'Run linter against style files'
   task stylelint: :environment do
     puts 'Running style linter...'
-    system('yarn run stylelint')
+    sh('yarn run stylelint')
   end
 
   desc 'Run all configured linters'

--- a/app/components/shared/progress_card_component.html.erb
+++ b/app/components/shared/progress_card_component.html.erb
@@ -8,25 +8,25 @@
         <%= render progress_card_step_component(step: SubmissionPresenter::CITATION_STEP, label: 'Citation details verified') %>
       <% end %>
       <%= tag.li 'aria-label': aria_label_for_step(step: SubmissionPresenter::ABSTRACT_STEP, label: 'Abstract provided') do %>
-        <%= render progress_card_step_component(step: SubmissionPresenter::ABSTRACT_STEP, label: 'Abstract provided') %></li>
+        <%= render progress_card_step_component(step: SubmissionPresenter::ABSTRACT_STEP, label: 'Abstract provided') %>
       <% end %>
       <%= tag.li 'aria-label': aria_label_for_step(step: SubmissionPresenter::FORMAT_STEP, label: 'Format reviewed') do %>
-        <%= render progress_card_step_component(step: SubmissionPresenter::FORMAT_STEP, label: 'Format reviewed') %></li>
+        <%= render progress_card_step_component(step: SubmissionPresenter::FORMAT_STEP, label: 'Format reviewed') %>
       <% end %>
       <%= tag.li 'aria-label': aria_label_for_step(step: SubmissionPresenter::DISSERTATION_STEP, label: 'Dissertation uploaded') do %>
-        <%= render progress_card_step_component(step: SubmissionPresenter::DISSERTATION_STEP, label: 'Dissertation uploaded') %></li>
+        <%= render progress_card_step_component(step: SubmissionPresenter::DISSERTATION_STEP, label: 'Dissertation uploaded') %>
       <% end %>
       <%= tag.li 'aria-label': aria_label_for_step(step: SubmissionPresenter::SUPPLEMENTAL_FILES_STEP, label: 'Supplemental files uploaded') do %>
-        <%= render progress_card_step_component(step: SubmissionPresenter::SUPPLEMENTAL_FILES_STEP, label: 'Supplemental files uploaded') %></li>
+        <%= render progress_card_step_component(step: SubmissionPresenter::SUPPLEMENTAL_FILES_STEP, label: 'Supplemental files uploaded') %>
       <% end %>
       <%= tag.li 'aria-label': aria_label_for_step(step: SubmissionPresenter::PERMISSION_FILES_STEP, label: 'Permission files uploaded') do %>
-        <%= render progress_card_step_component(step: SubmissionPresenter::PERMISSION_FILES_STEP, label: 'Permission files uploaded') %></li>
+        <%= render progress_card_step_component(step: SubmissionPresenter::PERMISSION_FILES_STEP, label: 'Permission files uploaded') %>
       <% end %>
       <%= tag.li 'aria-label': aria_label_for_step(step: SubmissionPresenter::RIGHTS_STEP, label: 'License terms applied') do %>
-        <%= render progress_card_step_component(step: SubmissionPresenter::RIGHTS_STEP, label: 'License terms applied') %></li>
+        <%= render progress_card_step_component(step: SubmissionPresenter::RIGHTS_STEP, label: 'License terms applied') %>
       <% end %>
       <%= tag.li 'aria-label': aria_label_for_step(step: SubmissionPresenter::SUBMITTED_STEP, label: 'Submitted to Registrar') do %>
-        <%= render progress_card_step_component(step: SubmissionPresenter::SUBMITTED_STEP, label: 'Submitted to Registrar', step_at: submitted_at) %></li>
+        <%= render progress_card_step_component(step: SubmissionPresenter::SUBMITTED_STEP, label: 'Submitted to Registrar', step_at: submitted_at) %>
       <% end %>
     <hr>
       <li aria-label="Verified by Final Reader, Pending">


### PR DESCRIPTION
Herb was running before but parse errors were not correctly being flagged as errors, so CI was always passing. Use rake `sh()` instead of `system()` to do what we wanted in the first place.
