### PR TITLE
Add recurring job to send ready_for_cataloging email

### DIFF
--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -3,6 +3,10 @@
 # Mailer for sending cataloging report emails for new submissions
 class SubmissionMailer < ApplicationMailer
   def ready_for_cataloging
+    return unless mailable_environment?
+
+    Honeybadger.check_in(Settings.honeybadger_checkins.ready_for_cataloging)
+
     # ETDs loaded since yesterday morning
     @etds_uncataloged_new = Submission.ils_records_created_since_yesterday_morning.order(:folio_instance_hrid)
     # All ETDs awaiting full cataloging
@@ -10,8 +14,6 @@ class SubmissionMailer < ApplicationMailer
                                       .order(:folio_instance_hrid)
 
     return if @etds_uncataloged_all.empty?
-
-    return unless environment.in?(Settings.mailable_environments)
 
     mail(subject: "[#{environment.upcase}] ETDs ready to be cataloged",
          template_name: 'ready_for_cataloging')
@@ -21,5 +23,9 @@ class SubmissionMailer < ApplicationMailer
 
   def environment
     Honeybadger.config[:env]
+  end
+
+  def mailable_environment?
+    environment.in?(Settings.mailable_environments)
   end
 end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,3 +13,6 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+  ready_for_cataloging:
+    command: "SubmissionMailer.ready_for_cataloging.deliver_now"
+    schedule: every weekday at 6am

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -66,3 +66,9 @@ mailable_environments:
 
 # Skip ETDs in the SDR Graveyard (withdrawn by registrar) or lost to us (possibly in great ETD migration of 2012)
 skip_cataloging_alert: ['druid:gh926rx4162', 'druid:wz924gg6479']
+
+# checkin keys for honeybadger (actual keys are in shared_configs per environment as needed)
+# see https://app.honeybadger.io/projects/55164/check_ins
+honeybadger_checkins:
+  catalog_status: test
+  ready_for_cataloging: test

--- a/spec/mailers/submission_mailer_spec.rb
+++ b/spec/mailers/submission_mailer_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe SubmissionMailer do
     ActionMailer::Base.deliveries = []
     # Do not send honeybadger notifications in test suite!
     allow(Honeybadger).to receive(:notify)
+    allow(Honeybadger).to receive(:check_in)
   end
 
   describe '#ready_for_cataloging' do
@@ -36,6 +37,7 @@ RSpec.describe SubmissionMailer do
       expect(mail.encoded).to include("<a href=\"#{etd_url}\">#{etd_title}")
       expect(mail.subject).to eq('[TEST] ETDs ready to be cataloged')
       expect(mail.to).to eq(['fake-report-list@example.com'])
+      expect(Honeybadger).to have_received(:check_in).with(Settings.honeybadger_checkins.ready_for_cataloging)
     end
   end
 
@@ -54,6 +56,7 @@ RSpec.describe SubmissionMailer do
       it 'does not send the email' do
         mail = described_class.ready_for_cataloging
         expect(mail.encoded).to be_nil
+        expect(Honeybadger).to have_received(:check_in).with(Settings.honeybadger_checkins.ready_for_cataloging)
       end
     end
   end


### PR DESCRIPTION
Fixes #130 

- Adds a  basic job to enqueue the SubmissionMailer#ready_for_cataloging mailer
- Adds a honeybadger checkin to the SubmissionMailer to avoid the extra shell work used in hydra_etd
- Implements using SolidQueue recurring configuration to avoid adding the `whenever` gem 