### PR TITLE
Declare cocina-models dependency explicitly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'bootsnap', require: false
 gem 'actionpack-xml_parser' # XML parameter parsing for Rails
 gem 'action_policy' # Authorization framework for Rails
 gem 'activeadmin'
+gem 'cocina-models', '~> 0.105'
 gem 'config'
 gem 'dor-services-client'
 gem 'druid-tools'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -683,6 +683,7 @@ DEPENDENCIES
   capistrano-rails
   capybara
   capybara-lockstep
+  cocina-models (~> 0.105)
   config
   cssbundling-rails
   cyperful


### PR DESCRIPTION
The app is currently fully dependent on the cocina-models gem and only gets it as a transitive dependency of DSC. It should be an explicit dependency.
