### PR TITLE
Add file descriptions to permissions files

### DIFF
--- a/app/components/edit/permission_files_step_component.html.erb
+++ b/app/components/edit/permission_files_step_component.html.erb
@@ -36,7 +36,7 @@
       </div>
     </div>
 
-    <% if permission_files.attached? %>
+    <% if permission_files.any? %>
       <%= render Shared::PermissionFilesStepBodyTableComponent.new(submission:, with_remove: true) %>
     <% end %>
 
@@ -44,7 +44,9 @@
       <% submission.permission_files.each do |permission_file| %>
         <%= form.hidden_field :permission_files, multiple: true, value: permission_file.signed_id, id: nil %>
       <% end %>
-      <% if permissions_provided? %>
+    <% end %>
+    <% if permissions_provided? %>
+      <%= form_with model: submission, url: attach_permission_files_submission_path(submission) do |form| %>
         <%= form.label :permission_files, 'Upload permission files (maximum size 1GB)', class: 'form-label' %>
         <%= form.file_field :permission_files, accept: 'application/pdf', multiple: true, data: { controller: 'submit', action: 'submit#submit' }, class: 'form-control', style: 'width: 350px;' %>
       <% end %>

--- a/app/components/edit/permission_files_step_component.rb
+++ b/app/components/edit/permission_files_step_component.rb
@@ -22,13 +22,13 @@ module Edit
     end
 
     def no_permissions_action
-      permission_files.attached? ? 'click->submit#warn' : 'submit#submit'
+      permission_files.any? ? 'click->submit#warn' : 'submit#submit'
     end
 
     def done_disabled?
       return false unless permissions_provided?
 
-      !permission_files.attached?
+      permission_files.none?
     end
   end
 end

--- a/app/components/shared/permission_files_step_body_table_component.html.erb
+++ b/app/components/shared/permission_files_step_body_table_component.html.erb
@@ -21,5 +21,30 @@
         <% end %>
       <% end %>
     <% end %>
+    <% component.with_row colspan: 5 do |row_component| %>
+      <%= row_component.with_cell do %>
+        <% if with_remove %>
+          <% form_with model: permission_file, id: "edit_permission_file_#{permission_file.id}" do |form| %>
+            <div class="flex-grow-1">
+              <div class="d-flex align-items-start">
+                <div class="m-1">
+                  <%= form.label :description, 'File description:', class: 'form-label fw-bold' %>
+                </div>
+                <div class="m-1">
+                  <%= form.text_field :description, class: 'form-control', size: 75, data: { controller: 'submit', action: 'blur->submit#submit' } %>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        <% else %>
+          <div class="flex-grow-1">
+            <div class="d-flex align-items-start">
+              <div class="m-1 fw-bold">File description:</div>
+              <div class="m-1"><%= permission_file.description %></div>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/controllers/permission_files_controller.rb
+++ b/app/controllers/permission_files_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Controller for Permission Files
+class PermissionFilesController < ApplicationController
+  before_action :set_permission_file
+  before_action :set_submission
+
+  def update
+    # All validation happens client-side, so not validating here.
+    authorize! @submission
+
+    @permission_file.update!(permission_file_params)
+    redirect_to edit_submission_path(@submission.dissertation_id)
+  end
+
+  private
+
+  def set_permission_file
+    @permission_file = PermissionFile.find(params[:id])
+  end
+
+  def set_submission
+    @submission = @permission_file.submission
+  end
+
+  def permission_file_params
+    params.expect(permission_file: [:description])
+  end
+end

--- a/app/models/permission_file.rb
+++ b/app/models/permission_file.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Model for permission files.
+class PermissionFile < ApplicationRecord
+  belongs_to :submission, inverse_of: :permission_files
+  has_one_attached :file, dependent: :purge_later
+
+  delegate :blob, :filename, :content_type, :byte_size, to: :file
+end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -12,10 +12,12 @@ class Submission < ApplicationRecord
   # Active Storage attachments
   has_one_attached :dissertation_file, dependent: :purge_later
   has_one_attached :augmented_dissertation_file, dependent: :purge_later
+
   has_many :supplemental_files, dependent: :destroy, inverse_of: :submission
   accepts_nested_attributes_for :supplemental_files, allow_destroy: true
 
-  has_many_attached :permission_files, dependent: :purge_later
+  has_many :permission_files, dependent: :destroy, inverse_of: :submission
+  accepts_nested_attributes_for :permission_files, allow_destroy: true
 
   validates :dissertation_id, presence: true
   validates :druid, presence: true

--- a/app/policies/submission_policy.rb
+++ b/app/policies/submission_policy.rb
@@ -3,7 +3,7 @@
 # Policy for managing submissions
 class SubmissionPolicy < ApplicationPolicy
   alias_rule :preview?, to: :show?
-  alias_rule :edit?, :submit?, :review?, :attach_supplemental_files?, to: :update?
+  alias_rule :edit?, :submit?, :review?, :attach_supplemental_files?, :attach_permission_files?, to: :update?
 
   def show?
     author? || admin?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,10 +19,12 @@ Rails.application.routes.draw do
       get :reader_review
       get :preview # Signature page preview
       patch :attach_supplemental_files
+      patch :attach_permission_files
     end
   end
 
   resources :supplemental_files, only: %i[update]
+  resources :permission_files, only: %i[update]
   resources :etds, only: %i[index create]
 
   mount MissionControl::Jobs::Engine, at: '/jobs'

--- a/db/migrate/20250908164649_add_permission_files_table.rb
+++ b/db/migrate/20250908164649_add_permission_files_table.rb
@@ -1,0 +1,9 @@
+class AddPermissionFilesTable < ActiveRecord::Migration[8.0]
+  def change
+    create_table :permission_files do |t|
+      t.text :description
+      t.references :submission, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_26_150637) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_08_164649) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -50,6 +50,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_26_150637) do
     t.datetime "updated_at", precision: nil, null: false
     t.index ["submission_id"], name: "index_attachments_on_submission_id"
     t.index ["uploaded_file_id"], name: "index_attachments_on_uploaded_file_id"
+  end
+
+  create_table "permission_files", force: :cascade do |t|
+    t.text "description"
+    t.bigint "submission_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["submission_id"], name: "index_permission_files_on_submission_id"
   end
 
   create_table "readers", force: :cascade do |t|
@@ -161,6 +169,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_26_150637) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "attachments", "submissions"
   add_foreign_key "attachments", "uploaded_files"
+  add_foreign_key "permission_files", "submissions"
   add_foreign_key "readers", "submissions"
   add_foreign_key "supplemental_files", "submissions"
 end

--- a/spec/components/edit/permission_files_step_component_spec.rb
+++ b/spec/components/edit/permission_files_step_component_spec.rb
@@ -33,11 +33,11 @@ RSpec.describe Edit::PermissionFilesStepComponent, type: :component do
       render_inline(described_class.new(submission:))
 
       expect(page).to have_css('h2', text: 'Upload permissions')
-      expect(page).to have_css('table#permission-files-table tr', count: 3)
+      expect(page).to have_css('table#permission-files-table tr', count: 5)
       rows = page.all('table#permission-files-table tbody tr')
       cells = rows[0].all('td')
       expect(cells[3]).to have_button('Remove', type: 'submit')
-      cells = rows[1].all('td')
+      cells = rows[2].all('td')
       expect(cells[3]).to have_button('Remove', type: 'submit')
     end
   end

--- a/spec/components/reader_review/permission_files_component_spec.rb
+++ b/spec/components/reader_review/permission_files_component_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReaderReview::PermissionFilesComponent, type: :component do
+  let(:submission) { create(:submission, :with_advisors, :submitted) }
+
+  it 'renders the component' do
+    render_inline(described_class.new(submission:))
+
+    expect(page).to have_css('h2', text: 'Permission files')
+    row = page.all('#permission-files-table tbody tr')
+    expect(row[0]).to have_link('permission_1.pdf')
+    expect(row[1]).to have_content('Permission file permission_1.pdf')
+    expect(row[2]).to have_link('permission_2.pdf')
+    expect(row[3]).to have_content('Permission file permission_2.pdf')
+  end
+end

--- a/spec/components/shared/permission_files_step_body_help_component_spec.rb
+++ b/spec/components/shared/permission_files_step_body_help_component_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Shared::PermissionFilesStepBodyHelpComponent, type: :component do
+  it 'renders the help content for the permission files step' do
+    render_inline(described_class.new)
+
+    expect(page).to have_content('Does your dissertation include copyrighted material?')
+    expect(page).to have_content('Click Yes if your dissertation contains copyrighted material.')
+  end
+end

--- a/spec/components/shared/permission_files_step_body_table_component_spec.rb
+++ b/spec/components/shared/permission_files_step_body_table_component_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Shared::PermissionFilesStepBodyTableComponent, type: :component do
+  let(:submission) { create(:submission, :with_permission_files) }
+
+  it 'renders the component' do
+    render_inline(described_class.new(submission:))
+
+    expect(page).to have_css('table#permission-files-table tr', count: 5)
+    headers = page.all('table#permission-files-table thead th')
+    expect(headers[0]).to have_content('Permission File')
+    expect(headers[4]).to have_no_content('Remove')
+
+    rows = page.all('table#permission-files-table tbody tr')
+    cells = rows[0].all('th')
+    expect(cells[0]).to have_link('permission_1.pdf')
+    cells = rows[0].all('td')
+    expect(cells[1]).to have_content('1.6 KB')
+    expect(cells[2]).to have_css('time')
+    expect(cells[3]).to have_no_button('Remove', type: 'submit')
+
+    cells = rows[2].all('th')
+    expect(cells[0]).to have_link('permission_2.pdf')
+    cells = rows[2].all('td')
+    expect(cells[1]).to have_content('1.6 KB')
+    expect(cells[2]).to have_css('time')
+    expect(cells[3]).to have_no_button('Remove', type: 'submit')
+  end
+
+  context 'when with_remove is true' do
+    it 'renders the remove button' do
+      render_inline(described_class.new(submission:, with_remove: true))
+
+      headers = page.all('table#permission-files-table thead th')
+      expect(headers[4]).to have_content('Remove')
+
+      rows = page.all('table#permission-files-table tbody tr')
+      cells = rows[0].all('td')
+      expect(cells[3]).to have_button('Remove', type: 'submit')
+      cells = rows[2].all('td')
+      expect(cells[3]).to have_button('Remove', type: 'submit')
+    end
+  end
+end

--- a/spec/factories/permission_files.rb
+++ b/spec/factories/permission_files.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :permission_file do
+    submission
+
+    # Yes, this permission filename has a composed diacritic, so we test that they work.
+    trait :first_permission do
+      description { 'Permission file permission_1.pdf' }
+      file { Rack::Test::UploadedFile.new(file_fixture('permission_1.pdf'), 'application/pdf') }
+    end
+
+    trait :second_permission do
+      description { 'Permission file permission_2.pdf' }
+      file { Rack::Test::UploadedFile.new(file_fixture('permission_2.pdf'), 'application/pdf') }
+    end
+  end
+end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -39,8 +39,8 @@ FactoryBot.define do
     trait :with_permission_files do
       permission_files do
         [
-          Rack::Test::UploadedFile.new(file_fixture('permission_1.pdf'), 'application/pdf'),
-          Rack::Test::UploadedFile.new(file_fixture('permission_2.pdf'), 'application/pdf')
+          create(:permission_file, :first_permission),
+          create(:permission_file, :second_permission)
         ]
       end
     end

--- a/spec/system/edit_submission_spec.rb
+++ b/spec/system/edit_submission_spec.rb
@@ -175,6 +175,14 @@ RSpec.describe 'Edit Submission' do
         file_fixture('permission_2.pdf')
       ]
 
+      within("form#edit_permission_file_#{submission.permission_files.first.id}") do
+        fill_in 'File description:', with: 'This is a sample first permission file.'
+      end
+
+      within("form#edit_permission_file_#{submission.permission_files.last.id}") do
+        fill_in 'File description:', with: 'This is a sample second permission file.'
+      end
+
       click_button 'Done'
 
       btn = find_button('Edit this section')

--- a/spec/system/show_reader_review_spec.rb
+++ b/spec/system/show_reader_review_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe 'Show Submission', :rack_test do
     expect(page).to have_content('Supplemental file supplemental_2.pdf')
     expect(page).to have_css('h2', text: 'Permission files')
     expect(page).to have_link('permission_1.pdf')
+    expect(page).to have_content('Permission file permission_1.pdf')
     expect(page).to have_link('permission_2.pdf')
+    expect(page).to have_content('Permission file permission_2.pdf')
   end
 end

--- a/spec/system/show_submission_spec.rb
+++ b/spec/system/show_submission_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe 'Show Submission', :rack_test do
     expect(page).to have_content('Supplemental file supplemental_2.pdf')
     expect(page).to have_css('h2', text: 'Upload permissions')
     expect(page).to have_link('permission_1.pdf')
+    expect(page).to have_content('Permission file permission_1.pdf')
     expect(page).to have_link('permission_2.pdf')
+    expect(page).to have_content('Permission file permission_2.pdf')
     expect(page).to have_css('h2', text: 'Review and submit to Registrar')
   end
 end


### PR DESCRIPTION
Fixes #167 

This wraps up the work on the permissions files updates with the file description - basically a copy of what was done for supplemental files.