### PR TITLE
Support legacy routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  ActiveAdmin.routes(self)
-
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
-  # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-
-  # Defines the root path route ("/")
-  # root "posts#index"
 
   resources :submissions, only: %i[edit update show] do
     member do
@@ -25,5 +16,10 @@ Rails.application.routes.draw do
   resources :supplemental_files, only: %i[update]
   resources :etds, only: %i[index create]
 
+  get 'view/:id', to: redirect('/submissions/%{id}/reader_review'), as: :legacy_view_show
+  get 'submit/:id', to: redirect('/submissions/%{id}'), as: :legacy_submit_show
+  get 'submit/:id/edit', to: redirect('/submissions/%{id}/edit'), as: :legacy_submit_edit
+
   mount MissionControl::Jobs::Engine, at: '/jobs'
+  ActiveAdmin.routes(self)
 end

--- a/spec/requests/edit_submission_spec.rb
+++ b/spec/requests/edit_submission_spec.rb
@@ -23,11 +23,22 @@ RSpec.describe 'Editing a submission' do
       sign_in(submission.sunetid)
     end
 
-    it 'allows the student to edit the submission' do
+    it 'returns an HTTP 200 & sets the ORCID' do
       get edit_submission_path(submission)
 
       expect(response).to have_http_status(:ok)
       expect(submission.reload.orcid).to eq(TEST_ORCID)
+    end
+
+    context 'when the submission already has an ORCID' do
+      let(:submission) { create(:submission, :with_orcid) }
+
+      it 'returns an HTTP 200 & does not reset the ORCID' do
+        get edit_submission_path(submission)
+
+        expect(response).to have_http_status(:ok)
+        expect(submission.reload.orcid).to eq('0000-0002-1825-0097')
+      end
     end
   end
 end

--- a/spec/requests/legacy_endpoints_spec.rb
+++ b/spec/requests/legacy_endpoints_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Legacy routes' do
+  before do
+    sign_in('adminuser', groups: [Settings.groups.dlss])
+  end
+
+  describe 'GET /view/:id' do
+    let(:submission) { create(:submission, :submitted, :with_readers) }
+
+    it 'redirects to submission#reader_review' do
+      get legacy_view_show_path(submission)
+
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response.location).to end_with(reader_review_submission_path(submission))
+      follow_redirect!
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Faculty guide for reviewing theses and dissertations')
+    end
+  end
+
+  describe 'GET /submit/:id' do
+    let(:submission) { create(:submission, :submitted) }
+
+    it 'redirects to submission#show' do
+      get legacy_submit_show_path(submission)
+
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response.location).to end_with(submission_path(submission))
+      follow_redirect!
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('View your dissertation or thesis')
+    end
+  end
+
+  describe 'GET /submit/:id/edit' do
+    let(:submission) { create(:submission) }
+
+    before do
+      sign_in(submission.sunetid)
+    end
+
+    it 'redirects to submission#edit' do
+      get legacy_submit_edit_path(submission)
+
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response.location).to end_with(edit_submission_path(submission))
+      follow_redirect!
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Submit your dissertation or thesis')
+    end
+  end
+end

--- a/spec/requests/show_submission_spec.rb
+++ b/spec/requests/show_submission_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Showing a submission' do
+  let(:submission) { create(:submission) }
+
+  context 'when a student is sent to the show view for their submission' do
+    before do
+      sign_in(submission.sunetid)
+    end
+
+    it 'redirects the user to the edit view' do
+      get submission_path(submission)
+
+      expect(response).to have_http_status(:found)
+      expect(response.location).to end_with(edit_submission_path(submission))
+      follow_redirect!
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Submit your dissertation or thesis')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #65
Supersedes #112 

The "legacy" routes are the ones that our partners in UIT & the Registrar's office point at. We want to maintain these routes.
