### PR TITLE
Get the active storage path from Settings.file_uploads_root

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -80,3 +80,5 @@ dlss_admin: 'dummy3'
 dlss_admin_pw: 'dummy4'
 
 copyright_instructions_url: 'https://drive.google.com/file/d/1do8J5rZvpDUrGrkOAYOZ96qNIvy0abfd/view'
+
+file_uploads_root: <%= Rails.root.join("storage") %>

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -4,7 +4,7 @@ test:
 
 local:
   service: Disk
-  root: <%= Rails.root.join("storage") %>
+  root: <%= Settings.file_uploads_root %>
 
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:


### PR DESCRIPTION
We need to set this path to a persistent path (the current workspace_dir should be fine) otherwise our storage path changes with ever deployment to be within the release path.

I'll put in a puppet PR to set this value to current workspace_dir, until that's applied, this wont have any effect (until the next deploy after that)