### PR TITLE
Remove extra whitespace from progress card.

### DIFF
--- a/app/components/shared/progress_card_component.html.erb
+++ b/app/components/shared/progress_card_component.html.erb
@@ -3,7 +3,7 @@
     <h2 class="h4 mb-0">Progress</h2>
   </div>
   <div class="card-body">
-    <ul class="list-unstyled">
+    <ul class="list-unstyled mb-0">
       <%= tag.li 'aria-label': aria_label_for_step(step: SubmissionPresenter::CITATION_STEP, label: 'Citation details verified') do %>
         <%= render progress_card_step_component(step: SubmissionPresenter::CITATION_STEP, label: 'Citation details verified') %>
       <% end %>


### PR DESCRIPTION
closes #277

<img width="329" height="667" alt="image" src="https://github.com/user-attachments/assets/3d26de75-070d-41ce-bf94-d30ce765c39f" />
