### PR TITLE
Fix embargo spec for east coasters.

### DIFF
--- a/spec/models/embargo_spec.rb
+++ b/spec/models/embargo_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Embargo do
 
   describe '.embargo_date' do
     let(:embargo_date) { described_class.embargo_date(start_date:, id: '2 years') }
-    let(:start_date) { Time.zone.today }
+    let(:start_date) { Time.zone.today.beginning_of_day }
     let(:expected_embargo_date) { (start_date + 2.years).to_time }
 
     it 'returns the correct embargo date' do


### PR DESCRIPTION
Before:
```
Failures:

  1) Embargo.embargo_date returns the correct embargo date
     Failure/Error: expect(embargo_date).to eq(expected_embargo_date)

       Expected #<ActiveSupport::TimeWithZone 2027-09-12 00:00:00 -07:00 (PDT)>
          to eq #<Time 2027-09-12 00:00:00 -04:00 (EDT)>

       Diff:

       ┌ (Key) ──────────────────────────┐
       │ ‹-› in expected, not in actual  │
       │ ‹+› in actual, not in expected  │
       │ ‹ › in both expected and actual │
       └─────────────────────────────────┘

         #<ActiveSupport::TimeWithZone {
           year: 2027,
           month: 9,
           day: 12,
           hour: 0,
           min: 0,
           sec: 0,
           subsec: 0,
       -   zone: "EDT",
       +   zone: "PDT",
       -   utc_offset: -14400,
       +   utc_offset: -25200,
           utc: #<Time {
             year: 2027,
             month: 9,
             day: 12,
       -     hour: 4,
       +     hour: 7,
             min: 0,
             sec: 0,
             subsec: 0,
             zone: "UTC",
             utc_offset: 0
           }>
         }>
     # ./spec/models/embargo_spec.rb:32:in 'block (3 levels) in <top (required)>'

Finished in 0.06831 seconds (files took 1.79 seconds to load)
3 examples, 1 failure

Failed examples:

rspec ./spec/models/embargo_spec.rb:31 # Embargo.embargo_date returns the correct embargo date

Randomized with seed 49940
```