### PR TITLE
Retry all jobs automatically on exceptions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,9 @@ Style/Documentation:
     - 'config/application.rb'
     - 'app/policies/**/*.rb'
 
+Style/Lambda:
+  EnforcedStyle: literal
+
 RSpec/ExampleLength:
   Enabled: false
 

--- a/app/components/elements/forms/toggle_component.rb
+++ b/app/components/elements/forms/toggle_component.rb
@@ -4,10 +4,10 @@ module Elements
   module Forms
     # Component for a toggle-like radio button group field
     class ToggleComponent < ApplicationComponent
-      renders_one :left_toggle_option, lambda { |**args|
+      renders_one :left_toggle_option, ->(**args) {
         Elements::Forms::ToggleOptionComponent.new(position: :left, **args)
       }
-      renders_one :right_toggle_option, lambda { |**args|
+      renders_one :right_toggle_option, ->(**args) {
         Elements::Forms::ToggleOptionComponent.new(position: :right, **args)
       }
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,9 +1,4 @@
 # frozen_string_literal: true
 
 class ApplicationJob < ActiveJob::Base
-  # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
-
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
 end

--- a/app/jobs/catalog_status_job.rb
+++ b/app/jobs/catalog_status_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Job to update catalog status of ETDs and trigger accessioning when ready
-class CatalogStatusJob < ApplicationJob
+class CatalogStatusJob < RetriableJob
   def perform
     Honeybadger.check_in(Settings.honeybadger_checkins.catalog_status)
 

--- a/app/jobs/create_stub_marc_record_job.rb
+++ b/app/jobs/create_stub_marc_record_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Create stub MARC record for ETD
-class CreateStubMarcRecordJob < ApplicationJob
+class CreateStubMarcRecordJob < RetriableJob
   queue_as :submit_marc
 
   def perform(druid)

--- a/app/jobs/retriable_job.rb
+++ b/app/jobs/retriable_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# SolidQueue does not auto-retry jobs so we use ActiveJob to accomplish the same thing.
+class RetriableJob < ApplicationJob
+  # This includes the first run plus all retries
+  MAX_ATTEMPTS = 5
+
+  # Retriable jobs should retry when any exception is raised. Retry
+  # `MAX_ATTEMPTS` times, and use exponential backoff so that the attempts are
+  # spread across a span of roughly ten minutes.
+  #
+  # If the number of attempts hits the max, log and alert that this has happened.
+  retry_on StandardError, attempts: MAX_ATTEMPTS,
+                          wait: ->(executions) { (executions**4) + (Kernel.rand * (executions**3)) + 2 } do |job, error|
+    # We're out of retries
+    Rails.logger.error(
+      "Job #{job.job_id} was failed after #{MAX_ATTEMPTS} runs due to #{error.class}: #{error.message}"
+    )
+    Honeybadger.context(job_id: job.job_id, attempts: MAX_ATTEMPTS)
+    raise error
+  end
+end

--- a/app/models/concerns/submission_admin_concern.rb
+++ b/app/models/concerns/submission_admin_concern.rb
@@ -25,14 +25,14 @@ module SubmissionAdminConcern
     scope :at_submitted, -> { has_submitted_at.not_reader_approved }
     scope :at_reader_approved, -> { reader_approved.not_registrar_approved.has_submitted_at }
     scope :at_registrar_approved, -> { registrar_approved.no_catalog_record_id.reader_approved.has_submitted_at }
-    scope :at_ils_loaded, lambda {
+    scope :at_ils_loaded, -> {
       has_catalog_record_id.ils_record_not_updated.registrar_approved.reader_approved.has_submitted_at
     }
-    scope :at_ils_cataloged, lambda {
+    scope :at_ils_cataloged, -> {
       ils_record_updated.accessioning_not_started.has_catalog_record_id.registrar_approved
                         .reader_approved.has_submitted_at
     }
-    scope :at_accessioning_started, lambda {
+    scope :at_accessioning_started, -> {
       accessioning_started.ils_record_updated.has_catalog_record_id.registrar_approved.reader_approved.has_submitted_at
     }
   end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -28,7 +28,7 @@ class Submission < ApplicationRecord
 
   # This scope checks for ETDs that have been sent to the ILS since yesterday at 6am and have not yet been updated.
   # It is used to by a cron job to send reminder emails to the catalogers
-  scope :ils_records_created_since_yesterday_morning, lambda {
+  scope :ils_records_created_since_yesterday_morning, -> {
     at_ils_loaded.where('ils_record_created_at > ?', Time.now.yesterday.change(hour: 6).utc)
   }
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -55,6 +55,4 @@ set :solid_queue_systemd_use_hooks, true
 
 # configure capistrano-rails to work with propshaft instead of sprockets
 # (we don't have public/assets/.sprockets-manifest* or public/assets/manifest*.*)
-set :assets_manifests, lambda {
-  [release_path.join('public', fetch(:assets_prefix), '.manifest.json')]
-}
+set :assets_manifests, -> { [release_path.join('public', fetch(:assets_prefix), '.manifest.json')] }


### PR DESCRIPTION
Use backoff between executions to spread out job runs. When retries have been exhausted, log an error and send a Honeybadger notification.
