### PR TITLE
Make sass deprecation warnings less spammy

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "stylelint-config-standard-scss": "^15.0.1"
   },
   "scripts": {
-    "build:css:compile": "sass ./app/assets/stylesheets:./app/assets/builds --no-source-map --load-path=node_modules --load-path=$(bundle show activeadmin)/app/assets/stylesheets",
+    "build:css:compile": "sass ./app/assets/stylesheets:./app/assets/builds --no-source-map --load-path=node_modules --load-path=$(bundle show activeadmin)/app/assets/stylesheets --quiet-deps",
     "build:css:prefix": "postcss ./app/assets/builds/*.css --use=autoprefixer --replace",
     "build:css": "yarn build:css:compile && yarn build:css:prefix",
     "watch:css": "nodemon --watch ./app/assets/stylesheets/ --ext scss --exec \"yarn build:css\"",


### PR DESCRIPTION
This small change makes CSS precompilation less spammy by removing deprecation warnings we cannot ourselves resolve (e.g., because they are in a dependency like bootstrap). We only show warnings for the application scss now. This takes the output down from several hundred lines to about 40.
