### PR TITLE
Fix links on submission admin page.

### DIFF
--- a/spec/system/admin/resubmit_to_registrar_spec.rb
+++ b/spec/system/admin/resubmit_to_registrar_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Re-post submission to Registrar' do
   end
 
   it 'allows the user to re-post the submission' do
-    visit admin_submission_path(submission.id)
+    visit admin_submission_path(submission)
     expect(page).to have_content(submission.title)
     expect(page).to have_link('Re-post to registrar')
     accept_alert do


### PR DESCRIPTION
closes #339

This is because `Submission#to_param` is the dissertation ID.