### PR TITLE
Escape dollar signs in abstracts (for MARC import)

### DIFF
--- a/app/services/admin/dummy_submission_service.rb
+++ b/app/services/admin/dummy_submission_service.rb
@@ -13,9 +13,24 @@ module Admin
     end
 
     def call
-      dissertation_id = format('%010d', Kernel.rand(1..9_999_999_999))
+      new_submission.tap do |submission|
+        submission.druid = RegisterService.register(submission:).externalIdentifier
+        submission.readers.build(
+          sunetid: sunetid,
+          position: 1,
+          name: 'Pretender, Advisor',
+          readerrole: 'Advisor'
+        )
+        submission.save!
+      end
+    end
 
-      submission = Submission.create!(
+    private
+
+    attr_reader :sunetid
+
+    def new_submission
+      Submission.new(
         dissertation_id:,
         title: "Test Submission for #{sunetid} (#{dissertation_id})",
         sunetid: sunetid,
@@ -25,29 +40,12 @@ module Admin
         department: 'Philosophy',
         major: 'Philosophy',
         degreeconfyr: '2029',
-        etd_type: 'Thesis',
-        druid:
+        etd_type: 'Thesis'
       )
-      submission.readers.create!(
-        sunetid: sunetid,
-        position: 1,
-        name: 'Pretender, Advisor',
-        readerrole: 'Advisor'
-      )
-      submission
     end
 
-    private
-
-    attr_reader :sunetid
-
-    def druid
-      letters = 'bcdfghjkmnpqrstvwxyz'.chars.freeze
-
-      idx = (Submission.maximum(:id) || 0) + 1
-      format_str = 'druid:%s%s%03d%s%s%04d'
-      format(format_str, letters.sample, letters.sample,
-             idx / 10_000, letters.sample, letters.sample, idx)
+    def dissertation_id
+      format('%010d', Kernel.rand(1..9_999_999_999))
     end
   end
 end

--- a/app/services/marc/stub_record_creator.rb
+++ b/app/services/marc/stub_record_creator.rb
@@ -146,6 +146,9 @@ module Marc
     #   Note that 9950 was too big in the case of one abstract
     def add_abstract(marc)
       formatted_abstract = format_aacr2(etd.abstract)
+      # Dollar signs need to be escaped per Folio documentation or
+      # they are misinterpreted as subfield delimiters.
+      formatted_abstract.gsub!('$', '{dollar}')
       if formatted_abstract.length <= 9925
         marc.append(MARC::DataField.new('520', '3', ' ', ['a', formatted_abstract]))
       else

--- a/spec/services/admin/dummy_submission_service_spec.rb
+++ b/spec/services/admin/dummy_submission_service_spec.rb
@@ -3,14 +3,21 @@
 require 'rails_helper'
 
 RSpec.describe Admin::DummySubmissionService do
+  let(:dummy_cocina) { instance_double(Cocina::Models::DRO, externalIdentifier: 'druid:vm000jb0557') }
   let(:submission) { described_class.call(sunetid: 'testuser') }
 
-  it 'creates a dummy submission' do
+  before do
+    allow(RegisterService).to receive(:register).and_return(dummy_cocina)
+  end
+
+  it 'creates a dummy submission with a registered druid' do
     expect(submission).to be_a(Submission)
     expect(submission.sunetid).to eq('testuser')
 
     expect(submission.readers.count).to eq(1)
     reader = submission.readers.first
     expect(reader.sunetid).to eq('testuser')
+
+    expect(RegisterService).to have_received(:register).once
   end
 end

--- a/spec/services/marc/stub_record_creator_spec.rb
+++ b/spec/services/marc/stub_record_creator_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Marc::StubRecordCreator do
       areas for about a half century in fields including control,
       finance, signal processing, data mining, and machine learning.
       This thesis focuses on several topics involving convex optimization,
-      with the specific application of machine learning.
+      with the specific application of machine learning. $aves money!
     ABSTRACT
   end
   let(:submission) do
@@ -710,13 +710,20 @@ RSpec.describe Marc::StubRecordCreator do
     end
 
     describe '520 field for abstract' do
+      subject(:abstracts) { marc_record.fields('520') }
+
       it 'has one 520 for the abstract' do
-        expect(marc_record.fields('520').count).to eq(1)
+        expect(abstracts.count).to eq(1)
       end
 
       it 'has the contents of the abstract as subfield a' do
-        field = marc_record.fields('520').first
-        expect(field['a']).to eq creator.send(:format_aacr2, abstract)
+        expect(abstracts.first['a']).to eq(
+          'Convex optimization has been well-studied as a mathematical topic for more than a century, ' \
+          'and has been applied in practice in many application areas for about a half century in ' \
+          'fields including control, finance, signal processing, data mining, and machine learning. ' \
+          'This thesis focuses on several topics involving convex optimization, with the specific ' \
+          'application of machine learning. {dollar}aves money!.'
+        )
       end
     end
 


### PR DESCRIPTION
Fixes #307

Includes:
- **Escape dollar signs in abstracts when creating MARC stub**
- **Mint a real druid in dummy submissions so they can be tested end-to-end**
