### PR TITLE
Fix display of embargo duration in show/reader pages

### DIFF
--- a/app/components/shared/rights_step_body_component.rb
+++ b/app/components/shared/rights_step_body_component.rb
@@ -17,7 +17,7 @@ module Shared
       if last_registrar_action_at && /approved/i.match?(regapproval)
         if embargo.present? && embargo != 'immediately'
           "This #{etd_type_label} will be publicly available on <strong>#{formatted_release_date}" \
-            "</strong> (includes #{embargo} delay requested by the author)."
+            "</strong> (includes #{delay_duration_label} delay requested by the author)."
         else
           "This #{etd_type_label} will be publicly available on <strong>#{formatted_release_date}</strong>."
         end
@@ -43,6 +43,10 @@ module Shared
 
     def etd_type_label
       etd_type.downcase
+    end
+
+    def delay_duration_label
+      embargo.chomp('s').parameterize
     end
   end
 end

--- a/spec/components/reader_review/rights_step_component_spec.rb
+++ b/spec/components/reader_review/rights_step_component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ReaderReview::RightsStepComponent, type: :component do
       expect(rows.length).to eq(4)
       expect(page).to have_content(
         "This thesis will be publicly available on #{release_date_display} " \
-        '(includes 6 months delay requested by the author).'
+        '(includes 6-month delay requested by the author).'
       )
     end
   end


### PR DESCRIPTION
This changes how embargoes are labeled.
