### PR TITLE
Allow the registrar to send dissertations with only a single reader

### DIFF
--- a/app/controllers/etds_controller.rb
+++ b/app/controllers/etds_controller.rb
@@ -51,26 +51,24 @@ class EtdsController < ApplicationController
   end
 
   def etd_params
-    params.expect(DISSERTATION: [:dissertationid, :title, :type, :readerapproval, :readercomment, :regapproval,
-                                 :regcomment, :documentaccess, :schoolname, :degreeconfyr, :univid, :sunetid,
-                                 :readeractiondttm, :regactiondttm, :degree, :name, :vpname, :career, :program,
-                                 :plan,
-                                 { sub: [%i[deadline]] },
-                                 { subplan: [%i[code __content__]],
-                                   reader: [%i[sunetid name_prefix prefix name suffix type
-                                               univid readerrole finalreader]] }])
+    params.require(:DISSERTATION) # rubocop:disable Rails/StrongParametersExpect
+          .permit(:dissertationid, :title, :type, :readerapproval, :readercomment, :regapproval,
+                  :regcomment, :documentaccess, :schoolname, :degreeconfyr, :univid, :sunetid,
+                  :readeractiondttm, :regactiondttm, :degree, :name, :vpname, :career, :program, :plan,
+                  reader: %i[sunetid name_prefix prefix name suffix type univid readerrole finalreader],
+                  subplan: %i[code __content__])
   end
 
   def dissertation_id
-    etd_params.expect(:dissertationid)
+    etd_params.fetch(:dissertationid)
   end
 
   def title
-    etd_params.expect(:title).squish
+    etd_params.fetch(:title).squish
   end
 
   def readers
-    etd_params.expect(reader: [%i[sunetid name_prefix prefix name suffix type univid readerrole finalreader]])
+    Array(etd_params.fetch(:reader))
   end
 
   def degree

--- a/spec/requests/peoplesoft_submission_created_spec.rb
+++ b/spec/requests/peoplesoft_submission_created_spec.rb
@@ -26,55 +26,65 @@ RSpec.describe 'ETDs created from Peoplesoft upload' do
           <readerrole>External Reader</readerrole>
           <finalreader>No</finalreader>
         </reader>
-        <dissertationid>000123</dissertationid>
+        <dissertationid>#{dissertation_id}</dissertationid>
         <title>My etd</title>
         <type>Dissertation</type>
         <sunetid>student1</sunetid>
       </DISSERTATION>
     XML
   end
-  let(:druid) { 'druid:789' }
+  let(:druid) { 'druid:bc789df8765' }
   let(:dlss_admin_credentials) { ActionController::HttpAuthentication::Basic.encode_credentials(Settings.dlss_admin, Settings.dlss_admin_pw) }
   let(:objects_client) { instance_double(Dor::Services::Client::Objects, register: model_response) }
   let(:object_client) { instance_double(Dor::Services::Client::Object, workflow: workflow_client) }
   let(:workflow_client) { instance_double(Dor::Services::Client::ObjectWorkflow, create: true) }
   let(:model_response) { instance_double(Cocina::Models::DRO, externalIdentifier: druid) }
   let(:dissertation_id) { '000123' }
-  let(:params) do
-    {
-      'dissertationid' => dissertation_id,
-      'title' => 'My etd',
-      'reader' => [
-        {
-          'sunetid' => 'READ1',
-          'prefix' => 'Mr.',
-          'name' => 'Reader,First',
-          'suffix' => 'Jr.',
-          'type' => 'int',
-          'univid' => '05358772',
-          'readerrole' => 'Doct Dissert Advisor (AC)',
-          'finalreader' => 'No'
-        },
-        {
-          'sunetid' => ' ',
-          'prefix' => 'Dr',
-          'name' => 'Reader,Second',
-          'suffix' => ' ',
-          'type' => 'ext',
-          'univid' => ' ',
-          'readerrole' => 'External Reader',
-          'finalreader' => 'No'
-        }
-      ]
-    }
-  end
 
   before do
     allow(Honeybadger).to receive(:notify)
     allow(Dor::Services::Client).to receive_messages(objects: objects_client, object: object_client)
   end
 
-  describe 'POST /etds' do
+  it 'creates a new Etd' do
+    post '/etds',
+         params: data,
+         headers: { Authorization: dlss_admin_credentials,
+                    'Content-Type': 'application/xml' }
+
+    expect(response).to have_http_status(:created)
+    expect(response.body).to include('druid:bc789df8765 created')
+
+    submission = Submission.find_by(dissertation_id:)
+    expect(submission).not_to be_nil
+    expect(submission.druid).to eq druid
+    expect(submission.readers.count).to eq 2
+    expect(object_client).to have_received(:workflow).with('registrationWF')
+    expect(workflow_client).to have_received(:create).with(version: 1)
+  end
+
+  context 'when only a single reader is provided' do
+    let(:data) do
+      <<~XML
+        <DISSERTATION>
+          <reader>
+            <sunetid>READ1</sunetid>
+            <prefix>Mr.</prefix>
+            <name>Reader,First</name>
+            <suffix>Jr.</suffix>
+            <type>int</type>
+            <univid>05358772</univid>
+            <readerrole>Doct Dissert Advisor (AC)</readerrole>
+            <finalreader>No</finalreader>
+          </reader>
+          <dissertationid>000123</dissertationid>
+          <title>My etd</title>
+          <type>Dissertation</type>
+          <sunetid>student1</sunetid>
+        </DISSERTATION>
+      XML
+    end
+
     it 'creates a new Etd' do
       post '/etds',
            params: data,
@@ -82,12 +92,12 @@ RSpec.describe 'ETDs created from Peoplesoft upload' do
                       'Content-Type': 'application/xml' }
 
       expect(response).to have_http_status(:created)
-      expect(response.body).to include('druid:789 created')
+      expect(response.body).to include('druid:bc789df8765 created')
 
       submission = Submission.find_by(dissertation_id:)
       expect(submission).not_to be_nil
       expect(submission.druid).to eq druid
-      expect(submission.readers.count).to eq 2
+      expect(submission.readers.count).to eq 1
       expect(object_client).to have_received(:workflow).with('registrationWF')
       expect(workflow_client).to have_received(:create).with(version: 1)
     end


### PR DESCRIPTION
This happens sometimes (https://app.honeybadger.io/projects/55164/faults/124588348) and the old ETD app permitted this case. Heracles should too. What happened? Rails 8 introduced more secure/robust parameter parsing via `params.expect(...)` instead of `params.require(...).permit(...)`. Which is great! However, with XML payloads coming over, our built-in XML parser will parse a repeated element (e.g., `<reader>`) as an array, but if only one of that element is present, it is parsed as a hash. Until/unless we begin parsing incoming XML differently (like my lingering PR that changes this to use dry-rb...), we need to permit XML that has one or more reader elements. POSTs to this service are already locked down in a few ways (IP address, authN), so we can justify making this change.
