### PR TITLE
Allow user to change title on PeopleSoft side

### DIFF
--- a/app/controllers/etds_controller.rb
+++ b/app/controllers/etds_controller.rb
@@ -106,7 +106,7 @@ class EtdsController < ApplicationController
   def set_submission
     return render status: :bad_request, plain: invalid_xml_message unless valid_xml?
 
-    @submission = Submission.find_or_initialize_by(dissertation_id:, title:)
+    @submission = Submission.find_by(dissertation_id:) || Submission.new(dissertation_id:, title:)
     @message = @submission.new_record? ? 'created' : 'updated'
   end
 

--- a/spec/requests/peoplesoft_submission_created_spec.rb
+++ b/spec/requests/peoplesoft_submission_created_spec.rb
@@ -63,6 +63,57 @@ RSpec.describe 'ETDs created from Peoplesoft upload' do
     expect(workflow_client).to have_received(:create).with(version: 1)
   end
 
+  context 'when student creates a submission then edits the title' do
+    let(:data_with_new_title) do
+      <<~XML
+        <DISSERTATION>
+          <reader>
+            <sunetid>READ1</sunetid>
+            <prefix>Mr.</prefix>
+            <name>Reader,First</name>
+            <suffix>Jr.</suffix>
+            <type>int</type>
+            <univid>05358772</univid>
+            <readerrole>Doct Dissert Advisor (AC)</readerrole>
+            <finalreader>No</finalreader>
+          </reader>
+          <reader>
+            <sunetid> </sunetid>
+            <prefix>Dr</prefix>
+            <name>Reader,Second</name>
+            <suffix> </suffix>
+            <type>ext</type>
+            <univid> </univid>
+            <readerrole>External Reader</readerrole>
+            <finalreader>No</finalreader>
+          </reader>
+          <dissertationid>#{dissertation_id}</dissertationid>
+          <title>My changed etd</title>
+          <type>Dissertation</type>
+          <sunetid>student1</sunetid>
+        </DISSERTATION>
+      XML
+    end
+
+    it 'creates a new Etd' do
+      post '/etds',
+           params: data,
+           headers: { Authorization: dlss_admin_credentials,
+                      'Content-Type': 'application/xml' }
+
+      expect(response).to have_http_status(:created)
+      expect(response.body).to include('druid:bc789df8765 created')
+
+      post '/etds',
+           params: data_with_new_title,
+           headers: { Authorization: dlss_admin_credentials,
+                      'Content-Type': 'application/xml' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('druid:bc789df8765 updated')
+    end
+  end
+
   context 'when only a single reader is provided' do
     let(:data) do
       <<~XML


### PR DESCRIPTION
Prior to this patch, the ETDs controller did a Submission.find_or_initialize_by with both the dissertation ID and the title. We do not need the title to find a dissertation, though, and this thwarts finding the correct ETD when a user changes the title. Instead, separate this call into a find_by (with diss ID), or a new (with diss ID and title), which is logically identical to what find_or_initialize_by does.
