### PR TITLE
Standardize use of content instead of value for AlertComponent

### DIFF
--- a/app/components/edit/submitted_step_component.html.erb
+++ b/app/components/edit/submitted_step_component.html.erb
@@ -8,9 +8,13 @@
 
   <% component.with_body_content do %>
     <% if all_done? %>
-      <%= render Elements::StatusAlertComponent.new(value: "You have completed sections 1-#{step_range_end}. You can now review and submit to the Registrar.") %>
+      <%= render Elements::StatusAlertComponent.new do %>
+        You have completed sections 1-<%= step_range_end %>. You can now review and submit to the Registrar.
+      <% end %>
     <% else %>
-      <%= render Elements::StatusAlertComponent.new(value: "You must complete sections 1-#{step_range_end} before you can review and submit to the Registrar.", variant: :danger) %>
+      <%= render Elements::StatusAlertComponent.new(variant: :danger) do %>
+        You must complete sections 1-<%= step_range_end %> before you can review and submit to the Registrar.
+      <% end %>
     <% end %>
   <% end %>
 

--- a/app/components/elements/alert_component.html.erb
+++ b/app/components/elements/alert_component.html.erb
@@ -6,7 +6,7 @@
     <% if title.present? %>
         <div class="fw-semibold"><%= title %></div>
     <% end %>
-    <%= value || content %>
+    <%= content %>
   </div>
   <% if dismissible? %>
     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>

--- a/app/components/elements/alert_component.rb
+++ b/app/components/elements/alert_component.rb
@@ -15,14 +15,13 @@ module Elements
 
     # Variants are :danger, :success, :note, :info, :warning, :input
     # input is not part of the component library
-    def initialize(title: nil, variant: :info, dismissible: false, value: nil, data: {}, classes: [], id: nil,
+    def initialize(title: nil, variant: :info, dismissible: false, data: {}, classes: [], id: nil,
                    role: 'alert')
       raise ArgumentError, 'Invalid variant' unless %i[danger success note info warning input].include?(variant.to_sym)
 
       @title = title
       @variant = variant.to_sym
       @dismissible = dismissible
-      @value = value
       @data = data
       @classes = classes
       @id = id
@@ -30,7 +29,7 @@ module Elements
       super()
     end
 
-    attr_reader :title, :variant, :value, :data, :id, :role
+    attr_reader :title, :variant, :data, :id, :role
 
     def classes
       merge_classes(%w[alert d-flex shadow-sm align-items-center], variant_class, dismissible_class, @classes)
@@ -57,7 +56,7 @@ module Elements
     end
 
     def render?
-      title.present? || value.present? || content.present?
+      title.present? || content.present?
     end
   end
 end

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -9,7 +9,9 @@
   <div class="row gy-2">
     <div class="col-lg-8 order-2 order-lg-1">
       <% unless @current_user.sunetid == @submission.sunetid %>
-        <%= render Elements::StatusAlertComponent.new(title: 'Read-only administrative view', value: "This is a read-only view of the student's ETD submission", variant: :warning) %>
+        <%= render Elements::StatusAlertComponent.new(title: 'Read-only administrative view', variant: :warning) do %>
+          This is a read-only view of the student's ETD submission.
+        <% end %>
       <% end %>
 
       <%= render Show::WelcomeBannerComponent.new(submission: @submission) %>

--- a/spec/components/elements/alert_component_spec.rb
+++ b/spec/components/elements/alert_component_spec.rb
@@ -18,14 +18,6 @@ RSpec.describe Elements::AlertComponent, type: :component do
     end
   end
 
-  context 'with a value' do
-    it 'renders the alert with a value' do
-      render_inline(described_class.new(title: 'My title', value: 'My value'))
-
-      expect(page).to have_text('My value')
-    end
-  end
-
   context 'with a variant' do
     it 'renders the alert' do
       render_inline(described_class.new(title: 'My title', variant: :note))
@@ -41,7 +33,7 @@ RSpec.describe Elements::AlertComponent, type: :component do
     end
   end
 
-  context 'without title, value, or content' do
+  context 'without title or content' do
     it 'does not render' do
       render_inline(described_class.new(title: '').with_content(''))
 


### PR DESCRIPTION
While looking at copying components from heracles and h3 into a reusable gem, I realized here that the only use of `AlertComponent` is through `StatusAlertComponent` and we were inconsistent in our use of either `value` as a param or a content block. 

With that in mind, this removes the `value` param (partly to help reduce the number of params) and standardizes on using the content block for display content.