### PR TITLE
Allow show page to render before license is selected

### DIFF
--- a/app/components/shared/rights_step_body_component.html.erb
+++ b/app/components/shared/rights_step_body_component.html.erb
@@ -2,7 +2,9 @@
   <% component.with_row(label: 'Copyright Statement', values: [copyright_statement]) %>
   <% component.with_row(label: 'Creative Commons') do |row_component| %>
     <% row_component.with_cell do %>
-      <% if license.url %>
+      <% if license.nil? %>
+        <div>This work has not yet been licensed.</div>
+      <% elsif license.url %>
         <%= image_tag license.image, alt: license.name, class: 'cc-license-badge float-start me-3 mt-2' %>
         <div>This work is licensed under a <%= license.name %>.</div>
         <%= render Elements::ExternalLinkComponent.new(url: license.url) %>

--- a/spec/components/shared/rights_step_body_component_spec.rb
+++ b/spec/components/shared/rights_step_body_component_spec.rb
@@ -29,6 +29,19 @@ RSpec.describe Shared::RightsStepBodyComponent, type: :component do
     )
   end
 
+  context 'when the submission is barebones (e.g., no license selected)' do
+    let(:submission) { create(:submission) }
+
+    it 'renders the component' do
+      render_inline(described_class.new(submission:))
+
+      rows = page.all('table#copyright-details-table tbody tr')
+      expect(rows.length).to eq(4)
+      expect(rows[1]).to have_css('th', text: 'Creative Commons')
+      expect(rows[1]).to have_css('td', text: 'This work has not yet been licensed.')
+    end
+  end
+
   context 'when the submission has no cc license' do
     let(:cclicense) { '0' }
 


### PR DESCRIPTION
Addresses https://app.honeybadger.io/projects/55164/faults/125464644

This patches an error condition that we discovered today when the Registrar when to view an unsubmitted thesis before the user selected a license. This page should render.
