### PR TITLE
Provide warning and do not allow done when abstract is over 5000 length

### DIFF
--- a/app/components/edit/abstract_step_component.html.erb
+++ b/app/components/edit/abstract_step_component.html.erb
@@ -1,7 +1,7 @@
 <%= render Edit::StepComponent.new(step: SubmissionPresenter::ABSTRACT_STEP,
                                    submission:,
                                    title: 'Enter your abstract',
-                                   data: { controller: 'abstract', action: 'turbo:morph@window->abstract#warnFormatting' },
+                                   data: { controller: 'abstract', action: 'turbo:morph@window->abstract#warn' },
                                    done_data: { abstract_target: 'doneButton' },
                                    done_disabled: done_disabled?) do |component| %>
   <% component.with_help_content do %>
@@ -17,8 +17,9 @@
         <%= form.label :abstract, class: 'form-label' do %>
           <span class="fw-bold">Abstract</span> <%= helpers.required_field %>
         <% end %>
-        <%= form.text_area :abstract, rows: 10, class: 'form-control', data: { controller: 'submit', action: 'blur->submit#submit keyup->abstract#warnFormatting keyup->abstract#toggleButton', abstract_target: 'input' } %>
-        <div class="text-danger mt-1 d-none" role="alert" data-abstract-target="warning">Warning: Please remove any Markdown or LaTeX formatting tags, as these will not be rendered correctly.</div>
+        <%= form.text_area :abstract, rows: 10, class: 'form-control', data: { controller: 'submit', action: 'blur->submit#submit keyup->abstract#warn keyup->abstract#toggleButton', abstract_target: 'input' } %>
+        <div class="text-danger mt-1 d-none" role="alert" data-abstract-target="formatting">Warning: Please remove any Markdown or LaTeX formatting tags, as these will not be rendered correctly.</div>
+        <div class="text-danger mt-1 d-none" role="alert" data-abstract-target="length">Warning: Abstract length is limited to a maximum of 5,000 characters. Please revise your abstract accordingly before attempting to complete this step.</div>
       </div>
     <% end %>
   <% end %>

--- a/app/components/edit/abstract_step_component.rb
+++ b/app/components/edit/abstract_step_component.rb
@@ -10,8 +10,9 @@ module Edit
 
     attr_reader :submission
 
+    # Do not enable the Done button if the abstract is blank or exceeds max length of 5000 chars
     def done_disabled?
-      submission.abstract.blank?
+      submission.abstract.blank? || submission.abstract.length > 5000
     end
   end
 end

--- a/app/javascript/controllers/abstract_controller.js
+++ b/app/javascript/controllers/abstract_controller.js
@@ -1,27 +1,42 @@
 import { Controller } from '@hotwired/stimulus'
 
+// Maximum allowed length for the abstract sent to datacite when registering DOI
+// is 5000 characters.
+const MAX_ABSTRACT_LENGTH = 5000
+
 export default class extends Controller {
-  static targets = ['doneButton', 'warning', 'input']
+  static targets = ['doneButton', 'formatting', 'length', 'input']
 
   toggleButton () {
-    if (this.abstract.length > 0) {
+    if (this.abstract.length > 0 && this.abstract.length <= MAX_ABSTRACT_LENGTH) {
       this.doneButtonTarget.disabled = false
     } else {
       this.doneButtonTarget.disabled = true
+      this.warn()
     }
   }
 
   warnFormatting () {
     const warn = this.abstract.match(/\$.+\$/) || // e.g., $\sim 100\gev$-$1\tev$
       this.abstract.match(/\\[a-zA-Z]+\{.+\}/) // e.g., \cite{p-Jungman:1995df}
-    this.warningTarget.classList.toggle('d-none', !warn)
+    this.formattingTarget.classList.toggle('d-none', !warn)
+  }
+
+  warnLength () {
+    const tooLong = this.abstract.length > MAX_ABSTRACT_LENGTH
+    this.lengthTarget.classList.toggle('d-none', !tooLong)
   }
 
   get abstract () {
     return this.inputTarget.value.trim()
   }
 
-  inputTargetConnected () {
+  warn () {
     this.warnFormatting()
+    this.warnLength()
+  }
+
+  inputTargetConnected () {
+    this.warn()
   }
 }

--- a/spec/system/edit_submission_spec.rb
+++ b/spec/system/edit_submission_spec.rb
@@ -74,6 +74,9 @@ RSpec.describe 'Edit Submission' do
       expect(page).to have_css('div[role="alert"]',
                                text: 'Warning: Please remove any Markdown or LaTeX formatting tags')
 
+      fill_in 'Abstract', with: 'A' * 5001 # Exceeding max length
+      expect(page).to have_css('div[role="alert"]', text: 'Warning: Abstract length is limited to a maximum of 5,000')
+
       fill_in 'Abstract', with: 'This is a sample abstract for testing.'
       expect(page).to have_no_css('div[role="alert"]')
       click_button 'Done'


### PR DESCRIPTION
Fixes #436 

This uses the same pattern as the format warning to add a length warning. This works when typing or pasting into the field.

Note: At this time, the abstract is still saved to the submission record regardless of length, but the submission cannot be completed until it is edited to less than 5000 characters. This allows the warning to be displayed when the user refreshes or comes back to the screen. I think trimming to 5000 characters on save will likely lead to some confusion as the student could past in more than 5000 characters, see the warning, finish the other parts of the form and the warning would clear because we've saved the first 5000 characters of what they provided, so the abstract would be incomplete. Open to suggestion/design around that however. This does mean we should be ensuring we aren't sending 5000 characters elsewhere as well as a follow up check.

https://github.com/user-attachments/assets/7ccffa02-4718-43c9-9a68-1a5267c23fcc

