### PR TITLE
Allow embargo value to be blank

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -87,7 +87,7 @@ class Submission < ApplicationRecord
   validates :etd_type, presence: true, inclusion: { in: %w[Thesis Dissertation] }
   validates :sunetid, presence: true
   validates :title, presence: true
-  validates :embargo, inclusion: { in: [nil, '1 year', '2 years', 'immediately', '6 months'] }
+  validates :embargo, inclusion: { in: ['1 year', '2 years', 'immediately', '6 months'], allow_blank: true }
 
   # This scope checks for ETDs that have been sent to the ILS since yesterday at 6am and have not yet been updated.
   # It is used to by a cron job to send reminder emails to the catalogers
@@ -159,6 +159,8 @@ class Submission < ApplicationRecord
   end
 
   def embargo_release_date
+    return if embargo.blank?
+
     Embargo.embargo_date(start_date: last_registrar_action_at, id: embargo)
   end
 

--- a/app/services/admin/dummy_submission_service.rb
+++ b/app/services/admin/dummy_submission_service.rb
@@ -40,8 +40,7 @@ module Admin
         department: 'Philosophy',
         major: 'Philosophy',
         degreeconfyr: '2029',
-        etd_type: 'Thesis',
-        embargo: 'immediately'
+        etd_type: 'Thesis'
       )
     end
 

--- a/spec/services/admin/dummy_submission_service_spec.rb
+++ b/spec/services/admin/dummy_submission_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Admin::DummySubmissionService do
   it 'creates a dummy submission with a registered druid' do
     expect(submission).to be_a(Submission)
     expect(submission.sunetid).to eq('testuser')
-    expect(submission.embargo).to eq('immediately')
+    expect(submission.embargo).to be_nil
 
     expect(submission.readers.count).to eq(1)
     reader = submission.readers.first


### PR DESCRIPTION
The inclusion list for this field allows nil but does not allow an empty string, which is what the value is when "Select an option" is selected. If a user toggles from another value to "Select an option," the server returns an error page and a honeybadger alert is sent. Instead, we want the user to select this option, which has the side ffect of disabling the done button for this section of the form.
