### PR TITLE
Toggle done button on abstract form field on input events

### DIFF
--- a/app/components/edit/abstract_step_component.html.erb
+++ b/app/components/edit/abstract_step_component.html.erb
@@ -17,7 +17,7 @@
         <%= form.label :abstract, class: 'form-label' do %>
           <span class="fw-bold">Abstract</span> <%= helpers.required_field %>
         <% end %>
-        <%= form.text_area :abstract, rows: 10, class: 'form-control', data: { controller: 'submit', action: 'blur->submit#submit keyup->abstract#warn keyup->abstract#toggleButton', abstract_target: 'input' } %>
+        <%= form.text_area :abstract, rows: 10, class: 'form-control', data: { controller: 'submit', action: 'blur->submit#submit abstract#warn abstract#toggleButton', abstract_target: 'input' } %>
         <div class="text-danger mt-1 d-none" role="alert" data-abstract-target="formatting">Warning: Please remove any Markdown or LaTeX formatting tags, as these will not be rendered correctly.</div>
         <div class="text-danger mt-1 d-none" role="alert" data-abstract-target="length">Warning: Abstract length is limited to a maximum of 5,000 characters. Please revise your abstract accordingly before attempting to complete this step.</div>
       </div>

--- a/app/javascript/controllers/submit_controller.js
+++ b/app/javascript/controllers/submit_controller.js
@@ -3,8 +3,6 @@ import { Controller } from '@hotwired/stimulus'
 export default class extends Controller {
   submit (event) {
     this.element.form.requestSubmit()
-    // Disable form elements to wait for submission to complete.
-    this.element.form.querySelectorAll('input, button, textarea, select').forEach(el => { el.disabled = true })
   }
 
   warn (event) {


### PR DESCRIPTION
Connects to #410

This is yet another attempt to patch the currently unexplained behavior where a submission has a blank abstract despite having the abstract_provided attribute set to true. To date, the only way we have found to reproduce this behavior is to intentionally defeat it via steps we documented in #410, which seems highly unlikely to be done by ETD system users. The changes in this branch are twofold:

1. Prevent the intentional defeat scenario by attaching the stimulus actions to the `input` event instead of `keyup`. This also makes the done button function as expected when the user uses a mouse to paste (or cut) abstract text, which was not the case beforehand.
2. Move the Honeybadger warning closer to where users are putting submissions into this odd state so we can hopefully catch this a bit sooner.
