### PR TITLE
Guard against submissions getting accessioned more than once

### DIFF
--- a/app/jobs/start_accession_job.rb
+++ b/app/jobs/start_accession_job.rb
@@ -6,8 +6,16 @@ class StartAccessionJob < ApplicationJob
   queue_as :default
 
   # create metadata for the work item
-  def perform(druid)
+  def perform(druid) # rubocop:disable Metrics/AbcSize
     @druid = druid
+
+    if submission.accessioning_started?
+      Honeybadger.notify(
+        '[INFO] Attempted to accession the same submission more than once',
+        context: { submission: }
+      )
+      return
+    end
 
     copy_to_workspace
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -159,6 +159,10 @@ class Submission < ApplicationRecord
     /approved/i.match?(regapproval) && /approved/i.match?(readerapproval)
   end
 
+  def accessioning_started?
+    accessioning_started_at.present?
+  end
+
   def creative_commons_license
     CreativeCommonsLicense.find(cclicense)
   end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -112,11 +112,18 @@ FactoryBot.define do
     end
 
     trait :loaded_in_ils do
+      stub_record_in_ils
       sequence(:folio_instance_hrid) { |n| format('a%05<number>d', number: n) }
     end
 
     trait :cataloged_in_ils do
+      loaded_in_ils
       ils_record_updated_at { DateTime.parse('2020-03-10T15:00:00Z') }
+    end
+
+    trait :accessioning_started do
+      cataloged_in_ils
+      accessioning_started_at { DateTime.parse('2020-03-21T10:00:00Z') }
     end
   end
 end

--- a/spec/jobs/start_accession_job_spec.rb
+++ b/spec/jobs/start_accession_job_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe StartAccessionJob do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     allow(DruidTools::Druid).to receive(:new).and_return(druid_tools)
     allow(Sdr::ReleaseTagger).to receive(:tag)
+    allow(Honeybadger).to receive(:notify)
   end
 
   after do
@@ -68,6 +69,24 @@ RSpec.describe StartAccessionJob do
   end
 
   describe '#perform' do
+    context 'when accessioning has already started' do
+      let(:submission) { create(:submission, :accessioning_started) }
+
+      it 'guards against accessioning twice' do
+        job.perform(druid)
+
+        expect(object_client).not_to have_received(:update)
+        expect(Sdr::AdministrativeTagCreator).not_to have_received(:create)
+        expect(version_client).not_to have_received(:close)
+        expect(Sdr::ReleaseTagger).not_to have_received(:tag)
+
+        expect(Honeybadger).to have_received(:notify).once.with(
+          '[INFO] Attempted to accession the same submission more than once',
+          context: { submission: }
+        )
+      end
+    end
+
     it 'starts accessioning' do
       job.perform(druid)
 
@@ -102,6 +121,8 @@ RSpec.describe StartAccessionJob do
       expect(version_client).to have_received(:close).with(lane_id: 'high')
 
       expect(Sdr::ReleaseTagger).to have_received(:tag).with(druid:).once
+
+      expect(Honeybadger).not_to have_received(:notify)
     end
   end
 end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -60,6 +60,24 @@ RSpec.describe Submission do
     end
   end
 
+  describe '#accessioning_started?' do
+    context 'when accessioning_started_at property is present' do
+      subject(:submission) { build(:submission, :accessioning_started, druid:) }
+
+      it 'returns true' do
+        expect(submission.accessioning_started?).to be true
+      end
+    end
+
+    context 'when accessioning_started_at property is blank' do
+      subject(:submission) { build(:submission, druid:) }
+
+      it 'returns false' do
+        expect(submission.accessioning_started?).to be false
+      end
+    end
+  end
+
   describe '#thesis?' do
     it 'returns true if the submission is a thesis' do
       expect(submission.thesis?).to be true


### PR DESCRIPTION
Connects to #496

In theory, this should never happen. I am not sure it has happened even once yet. However, we have a pullback request in #496 unlike any we've had to deal with before. Novel requests suggest novel solutions.

Here's the situation in a nutshell: a student has submitted a thesis that has been approved and had its stub MARC record created, and a publisher has asserted that this submission (the PDF itself) should be unavailable ("citation-only" access) for one year. Cathy has asked the cataloging department not to catalog this submission until we have a plan in place, since that will cause the submission to be accessioned.

The registrar has further requested that the submission then be accessible only by Stanford. A year after that (August 2028), the submission's embargo will trigger and be world-accessible.

We do not have any machinery to handle this sort of "gradual" embargo request, in which we will change the access controls for this twice. Note also that the ETD app does not currently support accessioning submissions with "citation-only" access. Here's the proposed plan for how to handle this novel pullback request:

1. Put in place a guard in the ETD app that prevents submissions from being accessioned twice, based on the presence of the `accessioning_started_at` property. (This PR.)
3. Set the `accessioning_started_at` property on the submission above in the ETD admin UI
4. Deploy this PR to production.
5. Notify Cataloging that this submission can now be safely cataloged without triggering accessioning.
6. When the ETD app next runs the `CatalogStatusJob` (which it runs hourly), the submission will be marked as having been cataloged and kick off the `StartAccessionJob` which will immediately short-circuit and log a Honeybadger notification.
7. I will then manually accession the submission (following the steps executed as defined in `StartAccessionJob` as "citation-only," verifying at each step that the PDF has not been accidentally shelved.
8. In August 2027, when the terms of the publisher demand have expired, a repository manager will manually change this submissions access controls from `citation-only / none` to `stanford / stanford`
9. In August 2028, the student-selected embargo will be put in place by embargo, changing the access controls from `stanford / stanford` to `world / world`.
