### PR TITLE
add admin button to rerun create marc record job

### DIFF
--- a/app/admin/submissions.rb
+++ b/app/admin/submissions.rb
@@ -172,15 +172,14 @@ ActiveAdmin.register Submission do
 
   member_action :resubmit_to_registrar, method: :post do
     # Re-post submission to Registrar (via PeopleSoft)
-    submission = Submission.find_by(dissertation_id: params[:id])
     message = begin
-                SubmissionPoster.call(submission:)
+                SubmissionPoster.call(submission: resource)
               rescue StandardError => e # rubocop:disable Layout/RescueEnsureAlignment
                 "ETD did not re-post to Registrar: #{e.message}"
               else
                 'ETD successfully re-posted to Registrar'
               end # rubocop:disable Layout/BeginEndAlignment
-    redirect_to admin_submission_path(submission), notice: message
+    redirect_to admin_submission_path(resource), notice: message
   end
 
   member_action :create_stub_marc_record, method: :post do

--- a/app/admin/submissions.rb
+++ b/app/admin/submissions.rb
@@ -183,6 +183,17 @@ ActiveAdmin.register Submission do
     redirect_to admin_submission_path(submission), notice: message
   end
 
+  member_action :create_stub_marc_record, method: :post do
+    if resource.ready_for_cataloging? && !resource.stub_record_written?
+      CreateStubMarcRecordJob.perform_later(resource.druid)
+      message = 'Stub MARC record job has been queued'
+    else
+      message = 'Stub MARC record job was not queued because this ETD is not eligible for cataloging'
+    end
+
+    redirect_to admin_submission_path(resource), notice: message
+  end
+
   action_item :resubmit_to_registrar, only: :show do
     # NOTE: `resource` here is the submission whose show page is being rendered.
     # This is ActiveAdmin-speak.
@@ -190,6 +201,15 @@ ActiveAdmin.register Submission do
       link_to 'Re-post to registrar', resubmit_to_registrar_admin_submission_path(resource),
               method: :post,
               data: { confirm: 'Are you sure you want to re-post to the registrar?' },
+              class: 'action-item-button'
+    end
+  end
+
+  action_item :create_stub_marc_record, only: :show do
+    if resource.ready_for_cataloging? && !resource.stub_record_written?
+      link_to 'Create stub MARC record', create_stub_marc_record_admin_submission_path(resource),
+              method: :post,
+              data: { confirm: 'Are you sure you want to create a stub MARC record?' },
               class: 'action-item-button'
     end
   end

--- a/app/policies/admin/submission_policy.rb
+++ b/app/policies/admin/submission_policy.rb
@@ -4,7 +4,7 @@ module Admin
   # Policy for managing submissions
   class SubmissionPolicy < ApplicationPolicy
     alias_rule :new?, to: :create?
-    alias_rule :create_stub_marc_record?, to: :manage?
+    alias_rule :create_stub_marc_record?, :resubmit_to_registrar?, to: :manage?
 
     def index?
       user.groups.dlss? || user.groups.reports?

--- a/app/policies/admin/submission_policy.rb
+++ b/app/policies/admin/submission_policy.rb
@@ -4,6 +4,7 @@ module Admin
   # Policy for managing submissions
   class SubmissionPolicy < ApplicationPolicy
     alias_rule :new?, to: :create?
+    alias_rule :create_stub_marc_record?, to: :manage?
 
     def index?
       user.groups.dlss? || user.groups.reports?

--- a/spec/requests/admin/create_stub_marc_record_spec.rb
+++ b/spec/requests/admin/create_stub_marc_record_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Create stub MARC record' do
+  let(:groups) { [Settings.groups.dlss] }
+
+  before { sign_in('dlss_user', groups:) }
+
+  context 'when the submission is ready for cataloging and has no stub record' do
+    let(:submission) { create(:submission, :ready_for_cataloging) }
+
+    before { allow(CreateStubMarcRecordJob).to receive(:perform_later) }
+
+    it 'shows the action and queues the job' do
+      get admin_submission_path(submission)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Create stub MARC record')
+
+      post create_stub_marc_record_admin_submission_path(submission)
+
+      expect(response).to redirect_to(admin_submission_path(submission))
+      expect(CreateStubMarcRecordJob).to have_received(:perform_later).with(submission.druid).once
+    end
+  end
+
+  context 'when the submission is not ready for cataloging' do
+    let(:submission) { create(:submission, :submitted) }
+
+    before { allow(CreateStubMarcRecordJob).to receive(:perform_later) }
+
+    it 'hides the action and does not queue the job' do
+      get admin_submission_path(submission)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include('Create stub MARC record')
+
+      post create_stub_marc_record_admin_submission_path(submission)
+
+      expect(response).to redirect_to(admin_submission_path(submission))
+      expect(CreateStubMarcRecordJob).not_to have_received(:perform_later)
+    end
+  end
+
+  context 'when the stub record has already been written' do
+    let(:submission) { create(:submission, :stub_record_in_ils) }
+
+    before { allow(CreateStubMarcRecordJob).to receive(:perform_later) }
+
+    it 'hides the action and does not queue the job' do
+      get admin_submission_path(submission)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include('Create stub MARC record')
+
+      post create_stub_marc_record_admin_submission_path(submission)
+
+      expect(response).to redirect_to(admin_submission_path(submission))
+      expect(CreateStubMarcRecordJob).not_to have_received(:perform_later)
+    end
+  end
+
+  context 'when the user is not in the DLSS group' do
+    let(:groups) { [] }
+    let(:submission) { create(:submission, :ready_for_cataloging) }
+
+    it 'does not allow the job to be queued' do
+      post create_stub_marc_record_admin_submission_path(submission)
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/requests/admin/resubmit_to_registrar_spec.rb
+++ b/spec/requests/admin/resubmit_to_registrar_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Re-post submission to Registrar' do
+  let(:groups) { [Settings.groups.dlss] }
+  let(:submission) { create(:submission, :reader_approved, :submitted) }
+
+  before { sign_in('dlss_user', groups:) }
+
+  context 'when the user is in the DLSS group' do
+    before { allow(SubmissionPoster).to receive(:call) }
+
+    it 'allows the submission to be re-posted' do
+      post resubmit_to_registrar_admin_submission_path(submission)
+
+      expect(response).to redirect_to(admin_submission_path(submission))
+      expect(SubmissionPoster).to have_received(:call).with(submission:).once
+    end
+  end
+
+  context 'when the user is not in the DLSS group' do
+    let(:groups) { [] }
+
+    it 'does not allow the submission to be re-posted' do
+      post resubmit_to_registrar_admin_submission_path(submission)
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #492 - add a button to the UI to manually trigger a create marc record job.

Will only be shown if reader/registrar approvals are in complete, and there isn't already a catalog ID in the ETD database.
Button is shown next to "Edit" button when viewing submission details.  When clicked, shows confirmation, when job queued, shoes message. See below

<img width="1102" height="384" alt="Screenshot 2026-07-13 at 2 08 06 PM" src="https://github.com/user-attachments/assets/f0155eb2-baac-48b8-9732-4d6877bbc2ed" />

<img width="617" height="235" alt="Screenshot 2026-07-13 at 2 08 15 PM" src="https://github.com/user-attachments/assets/a2df9011-81d8-4401-8394-c211dc7da048" />

<img width="1137" height="384" alt="Screenshot 2026-07-13 at 2 08 18 PM" src="https://github.com/user-attachments/assets/33571d4c-cf0f-4d36-b6aa-7ff729e0bcd2" />


Note: Codex assisted code.