### PR TITLE
allow user to enter in dissertation ID and temporary druid to create a new submision

### DIFF
--- a/app/admin/submissions.rb
+++ b/app/admin/submissions.rb
@@ -277,8 +277,13 @@ ActiveAdmin.register Submission do
   end
 
   form do |f|
-    f.semantic_errors # shows errors on :base
+    f.semantic_errors(*f.object.errors.attribute_names)
     f.inputs do
+      f.input :dissertation_id
+      if f.object.new_record?
+        f.input :druid,
+                hint: 'Enter a temporary value. Replace it with the druid returned by the registration service.'
+      end
       index_columns.each do |form_column|
         input form_column
       end

--- a/spec/requests/admin/submission_spec.rb
+++ b/spec/requests/admin/submission_spec.rb
@@ -64,6 +64,11 @@ RSpec.describe 'Admin - Submissions' do
         get '/admin/submissions/new'
 
         expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.at_css('#submission_dissertation_id')['name'])
+          .to eq('submission[dissertation_id]')
+        expect(response.parsed_body.at_css('#submission_druid')['name']).to eq('submission[druid]')
+        expect(response.parsed_body.at_css('#submission_druid_input .inline-hints').text)
+          .to include('Enter a temporary value')
       end
     end
 
@@ -84,6 +89,21 @@ RSpec.describe 'Admin - Submissions' do
         get '/admin/submissions/new'
 
         expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'POST /admin/submissions' do
+    context 'with a user in the DLSS group' do
+      let(:groups) { [Settings.groups.dlss] }
+
+      it 'shows validation errors when the submission is invalid' do
+        post '/admin/submissions', params: {
+          submission: attributes_for(:submission, title: '')
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body.css('ul.errors').text).to include("Title can't be blank")
       end
     end
   end


### PR DESCRIPTION
It is not currently possible to create a new submission in the admin interface because druid and dissertation_id are both required fields but are not on the form.  Additionally, the model level validations aren't shown, so you don't know what's happening.  This allows the user to create a new submission.  The only wrinkle is that the DRUID will need to be replaced later with the value from the registration service on the Rails console.  

So not sure how useful this actually is.  Alternatively, we can just remove the ability to create new submissions, in #521

<img width="1525" height="579" alt="Screenshot 2026-07-16 at 1 16 30 PM" src="https://github.com/user-attachments/assets/e12d6d27-d8e1-4e59-b9c0-1448e11d4375" />
