### PR TITLE
remove new submission button in admin interface

### DIFF
--- a/app/policies/admin/submission_policy.rb
+++ b/app/policies/admin/submission_policy.rb
@@ -19,7 +19,7 @@ module Admin
     end
 
     def create?
-      user.groups.dlss?
+      false
     end
 
     def manage?

--- a/spec/requests/admin/submission_spec.rb
+++ b/spec/requests/admin/submission_spec.rb
@@ -60,10 +60,10 @@ RSpec.describe 'Admin - Submissions' do
     context 'with a user in the DLSS group' do
       let(:groups) { [Settings.groups.dlss] }
 
-      it 'renders' do
+      it 'returns unauthorized' do
         get '/admin/submissions/new'
 
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 
@@ -82,6 +82,20 @@ RSpec.describe 'Admin - Submissions' do
 
       it 'returns unauthorized' do
         get '/admin/submissions/new'
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'POST /admin/submissions' do
+    context 'with a user in the DLSS group' do
+      let(:groups) { [Settings.groups.dlss] }
+
+      it 'returns unauthorized without creating a submission' do
+        expect do
+          post '/admin/submissions', params: { submission: attributes_for(:submission) }
+        end.not_to change(Submission, :count)
 
         expect(response).to have_http_status(:unauthorized)
       end

--- a/spec/system/admin/show_admin_dlss_spec.rb
+++ b/spec/system/admin/show_admin_dlss_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Show admin interface as DLSS user' do
     expect(page).to have_link('Delete Reader')
 
     click_link_or_button 'Submissions'
+    expect(page).to have_no_link('New Submission')
     within("#submission_#{submission.id}") do
       expect(page).to have_text(submission.title)
     end


### PR DESCRIPTION
As described in #520, the New Submission feature in the admin interface is not usable, because dissteration_id and druid are both required to create a new record, but it's not possible to enter them.  This removes the button to create a new submission.  Note there is still a button to create a "Dummy Submission" in stage which does work.

Alternatively, we can do #520, which gives the ability to enter both fields, even though the druid will later need to be replaced with the actual druid.