### PR TITLE
Increase retries from 5 to 10

### DIFF
--- a/app/jobs/retriable_job.rb
+++ b/app/jobs/retriable_job.rb
@@ -3,7 +3,7 @@
 # SolidQueue does not auto-retry jobs so we use ActiveJob to accomplish the same thing.
 class RetriableJob < ApplicationJob
   # This includes the first run plus all retries
-  MAX_ATTEMPTS = 5
+  MAX_ATTEMPTS = 10
 
   # Retriable jobs should retry when any exception is raised. Retry
   # `MAX_ATTEMPTS` times, and use exponential backoff so that the attempts are


### PR DESCRIPTION
We were noticing a few cases where the 5 tries to update the ILS with a stub record were failing, but then worked on retry.

Instead of making curators look at the internal Job queue (which they haven't been doing so far) to retry failed jobs we can start by increasing the number of retries and see if the problem goes away.

https://app.honeybadger.io/projects/55164/faults/131647618
